### PR TITLE
FIX: Check for shipping module before calculating shipping charges

### DIFF
--- a/code/Calculator.php
+++ b/code/Calculator.php
@@ -87,7 +87,7 @@ class Calculator{
 			$this->logDiscountAmount("Cart", $amount, $discount);
 		}
 
-		if($shipping = $this->order->getModifier("ShippingFrameworkModifier")){
+		if(\ClassInfo::exists('ShippingFrameworkModifier') && $shipping = $this->order->getModifier("ShippingFrameworkModifier")){
 			//work out all shipping-level discounts, and load into shippingpriceinfo
 			$shippingpriceinfo = new PriceInfo($shipping->Amount);
 			foreach($this->getShippingDiscounts()as $discount){


### PR DESCRIPTION
This is just a quick fix so that the module can work properly when the shop-shipping module is not installed.