### PR TITLE
Fixing notice when trying to set empty string

### DIFF
--- a/code/model/Discount.php
+++ b/code/model/Discount.php
@@ -315,6 +315,7 @@ class Discount extends DataObject{
 	 * @param string $val
 	 */
 	public function setFor($val){
+		if(!$val) return;
 		$map = array(
 			"Items" => array(1,0,0),
 			"Cart" => array(0,1,0),


### PR DESCRIPTION
This is to fix an error, found with this stacktrace:

```
ERROR [Notice]: Undefined index: 
IN POST /admin/discounts/OrderCoupon/GenerateCouponsForm
Line 324 in /var/www/public/shop_discount/code/model/Discount.php

Source
======
  315: 	 * @param string $val
  316: 	 */
  317: 	public function setFor($val){
  318: 		$map = array(
  319: 			"Items" => array(1,0,0),
  320: 			"Cart" => array(0,1,0),
  321: 			"Shipping" => array(0,0,1),
  322: 			"Order" => array(0,1,1)
  323: 		);
* 324: 		$mapping = $map[$val];
  325: 		$this->ForItems = $mapping[0];
  326: 		$this->ForCart = $mapping[1];
  327: 		$this->ForShipping = $mapping[2];
  328: 	}
  329: 
  330: 	public function getFor(){

Trace
=====
Discount->setFor()
ViewableData.php:125

ViewableData->__set(For,)
DataObject.php:2375

DataObject->setCastedField(For,)
Discount.php:263

Discount->setCastedField(For,)
FormField.php:217

FormField->saveInto(OrderCoupon)
Form.php:1271

Form->saveInto(OrderCoupon)
DiscountModelAdmin.php:130

DiscountModelAdmin->generate(Array,Form,SS_HTTPRequest)
Form.php:370

Form->httpSubmission(SS_HTTPRequest)
RequestHandler.php:288

RequestHandler->handleAction(SS_HTTPRequest,httpSubmission)
RequestHandler.php:200

RequestHandler->handleRequest(SS_HTTPRequest,DataModel)
RequestHandler.php:222

RequestHandler->handleRequest(SS_HTTPRequest,DataModel)
Controller.php:153

Controller->handleRequest(SS_HTTPRequest,DataModel)
LeftAndMain.php:441

LeftAndMain->handleRequest(SS_HTTPRequest,DataModel)
AdminRootController.php:93

AdminRootController->handleRequest(SS_HTTPRequest,DataModel)
Director.php:366

Director::handleRequest(SS_HTTPRequest,SkinnySession,DataModel)
Director.php:152

Director::direct(/admin/discounts/OrderCoupon/GenerateCouponsForm,DataModel)
main.php:190
```